### PR TITLE
Add Symfony ^3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ sudo: false
 matrix:
   include:
     - php: 7.1
+      env: SYMFONY_VERSION=^3.4
+    - php: 7.1
       env: SYMFONY_VERSION=^4.0
+    - php: 7.2
+      env: SYMFONY_VERSION=^3.4
     - php: 7.2
       env: SYMFONY_VERSION=^4.0
 

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
     ],
     "require": {
         "php": "^7.1.0",
-        "symfony/process": "^4.0",
-        "symfony/twig-bundle": "^4.0",
-        "symfony/dependency-injection": "^4.0"
+        "symfony/process": "^3.4 || ^4.0",
+        "symfony/twig-bundle": "^3.4 || ^4.0",
+        "symfony/dependency-injection": "^3.4 || ^4.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.9.2",


### PR DESCRIPTION
Hi,
It seems to me this bundle can also support Symfony ^3.4. Please downgrade its minimum requirements.

https://travis-ci.org/mxr576/mjml-bundle/builds/523843234
