### PR TITLE
Better exceptions for failed commands in BinaryRenderer

### DIFF
--- a/src/Renderer/BinaryRenderer.php
+++ b/src/Renderer/BinaryRenderer.php
@@ -37,13 +37,7 @@ final class BinaryRenderer implements RendererInterface
                 $this->bin,
                 '-V',
             ]);
-            $process->run();
-
-            if (true !== $process->isSuccessful()) {
-                throw new \InvalidArgumentException(sprintf(
-                    "Couldn't find the MJML binary"
-                ));
-            }
+            $process->mustRun();
 
             $this->mjmlVersion = self::VERSION_4;
             if (strpos($process->getOutput(), 'mjml-core: 4.') === false) {
@@ -83,21 +77,7 @@ final class BinaryRenderer implements RendererInterface
         // Create process
         $process = new Process($arguments);
         $process->setInput($mjmlContent);
-        $process->run();
-
-        // Executes after the command finishes
-        if (true !== $process->isSuccessful()) {
-            throw new \RuntimeException(sprintf(
-                'The exit status code \'%s\' says something went wrong:' . "\n"
-                . 'stderr: "%s"' . "\n"
-                . 'stdout: "%s"' . "\n"
-                . 'command: %s.',
-                $process->getStatus(),
-                $process->getErrorOutput(),
-                $process->getOutput(),
-                $process->getCommandLine()
-            ));
-        }
+        $process->mustRun();
 
         return $process->getOutput();
     }

--- a/tests/Renderer/BinaryRendererTest.php
+++ b/tests/Renderer/BinaryRendererTest.php
@@ -24,4 +24,11 @@ class BinaryRendererTest extends AbstractTestCase
         $renderer->render(file_get_contents(__DIR__.'/../fixtures/invalid.mjml'));
     }
 
+    public function testBinaryNotFound()
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $renderer = new BinaryRenderer('mjml-not-found', false);
+        $renderer->render(file_get_contents(__DIR__.'/../fixtures/basic.mjml'));
+    }
 }


### PR DESCRIPTION
We let symfony process handle the exceptions by using mustRun method.

Example:

```
The command "'mjml-not-found' '-V'" failed.

Exit Code: 127(Command not found)

Working directory: /Users/floranbrutel/dev/mjml-bundle

Output:
================


Error Output:
================
sh: line 0: exec: mjml-not-found: not found
" at
/Users/floranbrutel/dev/mjml-bundle/vendor/symfony/process/Process.php:256
/Users/floranbrutel/dev/mjml-bundle/src/Renderer/BinaryRenderer.php:40
We let symfony process handle the exceptions by using mustRun method
/Users/floranbrutel/dev/mjml-bundle/src/Renderer/BinaryRenderer.php:59
/Users/floranbrutel/dev/mjml-bundle/tests/Renderer/BinaryRendererTest.php:32
.
```