### PR TITLE
add support mjml-core: 4.5.0

### DIFF
--- a/src/Renderer/BinaryRenderer.php
+++ b/src/Renderer/BinaryRenderer.php
@@ -35,7 +35,7 @@ final class BinaryRenderer implements RendererInterface
         if ($this->mjmlVersion === null) {
             $process = new Process([
                 $this->bin,
-                '-V',
+                '--version',
             ]);
             $process->mustRun();
 


### PR DESCRIPTION
mjml-core: 4.5.0 has not prarameter "-V". It has only "--version".
otherwise 

command:
mjml -V

ACTUAL OUTPUT:
Command line error:
No input argument received

EXPECTED OUTPUT:
mjml-core: 4.5.0
mjml-cli: 4.5.0