### PR TITLE
added cache system on mjml generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 vendor/
 node_modules/
+cache/
 composer.lock
 package-lock.json
 phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12.0",
-        "phpunit/phpunit": "^7.0",
-        "matthiasnoback/symfony-config-test": "^4.1",
-        "symplify/easy-coding-standard": "^6.0|^7.0"
+        "phpunit/phpunit": "^7.0|^9.5",
+        "matthiasnoback/symfony-config-test": "^4",
+        "symplify/easy-coding-standard": "^6.0|^7.0|^9"
     },
     "scripts": {
         "cs-check": "vendor/bin/ecs check tests src",

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12.0",
-        "phpunit/phpunit": "^7.0|^9.5",
-        "matthiasnoback/symfony-config-test": "^4",
+        "phpunit/phpunit": "^7.0",
+        "matthiasnoback/symfony-config-test": "^4.0",
         "symplify/easy-coding-standard": "^6.0|^7.0|^9"
     },
     "scripts": {

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(ArraySyntaxFixer::class)
+        ->call('configure', [[
+            'syntax' => 'short',
+        ]]);
+
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PATHS, [
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
+
+    $parameters->set(Option::SETS, [
+        // run and fix, one by one
+        // SetList::SPACES,
+        // SetList::ARRAY,
+        // SetList::DOCBLOCK,
+        // SetList::NAMESPACES,
+        // SetList::CONTROL_STRUCTURES,
+        // SetList::CLEAN_CODE,
+        // SetList::PSR_12,
+        // SetList::PHP_70,
+        // SetList::PHP_71,
+    ]);
+};

--- a/src/DependencyInjection/MjmlExtension.php
+++ b/src/DependencyInjection/MjmlExtension.php
@@ -27,6 +27,8 @@ class MjmlExtension extends Extension
             $rendererDefinition->addArgument($config['options']['binary']);
             $rendererDefinition->addArgument($config['options']['minify']);
             $rendererDefinition->addArgument($config['options']['validation_level']);
+            $rendererDefinition->addArgument($container->getParameter('kernel.cache_dir'));
+            $rendererDefinition->addArgument($container->getParameter('kernel.debug'));
             $rendererDefinition->addArgument($config['options']['node']);
             $container->setDefinition($rendererDefinition->getClass(), $rendererDefinition);
             $rendererServiceId = $rendererDefinition->getClass();

--- a/src/Renderer/BinaryRenderer.php
+++ b/src/Renderer/BinaryRenderer.php
@@ -2,6 +2,9 @@
 
 namespace NotFloran\MjmlBundle\Renderer;
 
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\Process\Process;
 
 final class BinaryRenderer implements RendererInterface
@@ -34,67 +37,140 @@ final class BinaryRenderer implements RendererInterface
      */
     private $node;
 
-    public function __construct(string $bin, bool $minify, string $validationLevel, string $node = null)
-    {
+    /**
+     * @var bool
+     */
+    private $debug;
+
+    /**
+     * @var string
+     */
+    private $cacheDir;
+
+    /**
+     * BinaryRenderer constructor.
+     *
+     * @param string      $bin
+     * @param bool        $minify
+     * @param string      $validationLevel
+     * @param string      $cacheDir
+     * @param bool        $debug
+     * @param string|null $node
+     */
+    public function __construct(
+        string $bin,
+        bool $minify,
+        string $validationLevel,
+        string $cacheDir,
+        bool $debug,
+        string $node = null
+    ) {
         $this->bin = $bin;
         $this->minify = $minify;
         $this->validationLevel = $validationLevel;
         $this->node = $node;
+        $this->debug = $debug;
+        $this->cacheDir = $this->ensureDirExists(sprintf('%s/notFloran/mjml', $cacheDir));
     }
 
     public function getMjmlVersion(): int
     {
         if (null === $this->mjmlVersion) {
-            $command = [];
-            if ($this->node) {
-                $command[] = $this->node;
+            $cache = new FilesystemAdapter('notFloran_mjml', 0, $this->cacheDir);
+
+            /** @var CacheItem $version */
+            $version = $cache->getItem('mjml_version');
+
+            if (!$version->isHit()) {
+                $command = [];
+                if ($this->node) {
+                    $command[] = $this->node;
+                }
+
+                array_push($command, $this->bin, '--version');
+
+                $process = new Process($command);
+                $process->mustRun();
+
+                $version->set(self::VERSION_4);
+                if (false === strpos($process->getOutput(), 'mjml-core: 4.')) {
+                    $version->set(self::VERSION_BEFORE_4);
+                }
+
+                $cache->save($version);
             }
 
-            array_push($command, $this->bin, '--version');
-
-            $process = new Process($command);
-            $process->mustRun();
-
-            $this->mjmlVersion = self::VERSION_4;
-            if (false === strpos($process->getOutput(), 'mjml-core: 4.')) {
-                $this->mjmlVersion = self::VERSION_BEFORE_4;
-            }
+            $this->mjmlVersion = $version->get();
         }
 
         return $this->mjmlVersion;
     }
 
-    public function render(string $mjmlContent): string
+    /**
+     * @param string $mjmlContent
+     * @param string $templateName
+     *
+     * @return string
+     *
+     * @throws InvalidArgumentException
+     */
+    public function render(string $mjmlContent, string $templateName): string
     {
-        $version = $this->getMjmlVersion();
+        $templateKey = str_replace(['.', '/'], '_', $templateName);
+        $cache = new FilesystemAdapter('notFloran_mjml', 0, $this->cacheDir);
 
-        $command = [];
-        if ($this->node) {
-            $command[] = $this->node;
-        }
+        /** @var CacheItem $render */
+        $render = $cache->getItem($templateKey);
 
-        array_push($command, $this->bin, '-i', '-s');
+        if ($this->debug || !$render->isHit()) {
+            $version = $this->getMjmlVersion();
 
-        $strictArgument = '-l';
-        if (self::VERSION_4 === $version) {
-            $strictArgument = '--config.validationLevel';
-        }
-
-        array_push($command, $strictArgument, $this->validationLevel);
-
-        if (true === $this->minify) {
-            if (self::VERSION_4 === $version) {
-                array_push($command, '--config.minify', 'true');
-            } else {
-                $command[] = '-m';
+            $command = [];
+            if ($this->node) {
+                $command[] = $this->node;
             }
+
+            array_push($command, $this->bin, '-i', '-s');
+
+            $strictArgument = '-l';
+            if (self::VERSION_4 === $version) {
+                $strictArgument = '--config.validationLevel';
+            }
+
+            array_push($command, $strictArgument, $this->validationLevel);
+
+            if (true === $this->minify) {
+                if (self::VERSION_4 === $version) {
+                    array_push($command, '--config.minify', 'true');
+                } else {
+                    $command[] = '-m';
+                }
+            }
+
+            // Create process
+            $process = new Process($command);
+            $process->setInput($mjmlContent);
+            $process->mustRun();
+
+            $render->set($process->getOutput());
+
+            $cache->save($render);
         }
 
-        // Create process
-        $process = new Process($command);
-        $process->setInput($mjmlContent);
-        $process->mustRun();
+        return $render->get();
+    }
 
-        return $process->getOutput();
+    /**
+     * @param $dir
+     *
+     * @return string
+     */
+    private function ensureDirExists($dir): string
+    {
+        if (!is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+
+        return $dir;
     }
 }

--- a/src/Renderer/RendererInterface.php
+++ b/src/Renderer/RendererInterface.php
@@ -4,5 +4,5 @@ namespace NotFloran\MjmlBundle\Renderer;
 
 interface RendererInterface
 {
-    public function render(string $mjmlContent): string;
+    public function render(string $mjmlContent, string $templateName): string;
 }

--- a/src/Twig/Node.php
+++ b/src/Twig/Node.php
@@ -32,6 +32,6 @@ class Node extends Twig_Node
             ->write('$lines = explode("\n", $content);'.PHP_EOL)
             ->write('$content = preg_replace(\'/^\' . $matches[0]. \'/\', "", $lines);'.PHP_EOL)
             ->write('$content = implode("\n", $content);'.PHP_EOL)
-            ->write('echo $this->env->getExtension("'.Extension::class.'")->getMjml()->render($content);'.PHP_EOL);
+            ->write('echo $this->env->getExtension("'.Extension::class.'")->getMjml()->render($content, $this->getTemplateName());'.PHP_EOL);
     }
 }

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -6,6 +6,11 @@ use PHPUnit\Framework\TestCase;
 
 abstract class AbstractTestCase extends TestCase
 {
+    protected function getCacheDir(): string
+    {
+        return 'cache';
+    }
+
     protected function getMjmlBinary(): string
     {
         $binary = 'node_modules/.bin/mjml';

--- a/tests/Renderer/BinaryRendererTest.php
+++ b/tests/Renderer/BinaryRendererTest.php
@@ -9,8 +9,8 @@ class BinaryRendererTest extends AbstractTestCase
 {
     public function testBasicRender()
     {
-        $renderer = new BinaryRenderer($this->getMjmlBinary(), false, 'strict');
-        $html = $renderer->render(file_get_contents(__DIR__.'/../fixtures/basic.mjml'));
+        $renderer = new BinaryRenderer($this->getMjmlBinary(), false, 'strict', $this->getCacheDir(), true);
+        $html = $renderer->render(file_get_contents(__DIR__.'/../fixtures/basic.mjml'), 'basic.mjml');
 
         $this->assertContains('html', $html);
         $this->assertContains('Hello Floran from MJML and Symfony', $html);
@@ -20,22 +20,22 @@ class BinaryRendererTest extends AbstractTestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $renderer = new BinaryRenderer($this->getMjmlBinary(), false, 'strict');
-        $renderer->render(file_get_contents(__DIR__.'/../fixtures/invalid.mjml'));
+        $renderer = new BinaryRenderer($this->getMjmlBinary(), false, 'strict', $this->getCacheDir(), true);
+        $renderer->render(file_get_contents(__DIR__.'/../fixtures/invalid.mjml'), 'invalid.mjml');
     }
 
     public function testInvalidRenderWithSkipValidationLevel()
     {
-        $renderer = new BinaryRenderer($this->getMjmlBinary(), false, 'skip');
-        $html = $renderer->render(file_get_contents(__DIR__.'/../fixtures/invalid.mjml'));
+        $renderer = new BinaryRenderer($this->getMjmlBinary(), false, 'skip',$this->getCacheDir(), true);
+        $html = $renderer->render(file_get_contents(__DIR__.'/../fixtures/invalid.mjml'), 'invalid.mjml');
 
         $this->assertContains('html', $html);
     }
 
     public function testInvalidRenderWithSoftValidationLevel()
     {
-        $renderer = new BinaryRenderer($this->getMjmlBinary(), false, 'soft');
-        $html = $renderer->render(file_get_contents(__DIR__.'/../fixtures/invalid.mjml'));
+        $renderer = new BinaryRenderer($this->getMjmlBinary(), false, 'soft',$this->getCacheDir(), true);
+        $html = $renderer->render(file_get_contents(__DIR__.'/../fixtures/invalid.mjml'), 'invalid.mjml');
 
         $this->assertContains('html', $html);
     }
@@ -44,14 +44,14 @@ class BinaryRendererTest extends AbstractTestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $renderer = new BinaryRenderer('mjml-not-found', false, 'strict');
-        $renderer->render(file_get_contents(__DIR__.'/../fixtures/basic.mjml'));
+        $renderer = new BinaryRenderer('mjml-not-found', false, 'strict',$this->getCacheDir(), true);
+        $renderer->render(file_get_contents(__DIR__.'/../fixtures/basic.mjml'), 'basic.mjml');
     }
 
     public function testUseNode()
     {
-        $renderer = new BinaryRenderer($this->getMjmlBinary(), false, 'strict', $this->getNode());
-        $html = $renderer->render(file_get_contents(__DIR__.'/../fixtures/basic.mjml'));
+        $renderer = new BinaryRenderer($this->getMjmlBinary(), false, 'strict', $this->getCacheDir(), true, $this->getNode());
+        $html = $renderer->render(file_get_contents(__DIR__.'/../fixtures/basic.mjml'), 'basic.mjml');
 
         $this->assertContains('html', $html);
     }

--- a/tests/Twig/ExtensionTest.php
+++ b/tests/Twig/ExtensionTest.php
@@ -29,7 +29,7 @@ TWIG;
 
     private function getTemplate($template): TemplateWrapper
     {
-        $mjmlRenderer = new BinaryRenderer($this->getMjmlBinary(), false, 'strict');
+        $mjmlRenderer = new BinaryRenderer($this->getMjmlBinary(), false, 'strict', __DIR__.'/../../cache', true);
 
         $loader = new TwigArrayLoader(['index' => $template]);
         $twig = new Environment($loader, ['debug' => true, 'cache' => false]);


### PR DESCRIPTION
I added cache system on mjml generation, used only when debug mode is off.
For my use case, I send multiple email at the same time and mjml generation take  ~ 2s, with cache, only few ms is needed to return html.