### PR TITLE
Add return types to remove deprecation warning

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -8,7 +8,7 @@ use Symfony\Component\Process\ExecutableFinder;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('mjml');
         if (\method_exists($treeBuilder, 'getRootNode')) {

--- a/src/Twig/Node.php
+++ b/src/Twig/Node.php
@@ -19,7 +19,7 @@ class Node extends Twig_Node
     /**
      * Compile the provided mjml into html.
      */
-    public function compile(Compiler $compiler)
+    public function compile(Compiler $compiler): void
     {
         $compiler->addDebugInfo($this)
             ->write('ob_start();'.PHP_EOL)

--- a/src/Twig/TokenParser.php
+++ b/src/Twig/TokenParser.php
@@ -2,12 +2,13 @@
 
 namespace NotFloran\MjmlBundle\Twig;
 
+use Twig\Node\Node as Twig_Node;
 use Twig\Token;
 use Twig\TokenParser\AbstractTokenParser;
 
 class TokenParser extends AbstractTokenParser
 {
-    public function parse(Token $token)
+    public function parse(Token $token): Twig_Node
     {
         $line = $token->getLine();
 


### PR DESCRIPTION
With Symfony 5.4 I got the following deprecation warnings

>Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "NotFloran\MjmlBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.

>Method "Twig\TokenParser\TokenParserInterface::parse()" might add "Node" as a native return type declaration in the future. Do the same in implementation "NotFloran\MjmlBundle\Twig\TokenParser" now to avoid errors or add an explicit @return annotation to suppress this message.


I've added the appropriate return types to remove these messages.